### PR TITLE
add prettier config to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,11 @@
     "mathjs": "^13.0.3",
     "openai": "^4.56.0",
     "path": "^0.12.7"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "all"
   }
 }


### PR DESCRIPTION
My editor keeps trying to reformat files which means super annoying diffs.

This encodes (I think?) the code style present in the code in to the package.json, so prettier-based tooling won't bork up the formatting.